### PR TITLE
Fixed env path issues with windows

### DIFF
--- a/lib/commons/rscommons/dotenv.py
+++ b/lib/commons/rscommons/dotenv.py
@@ -2,6 +2,7 @@ import codecs
 import re
 import os
 import argparse
+from pathlib import Path
 
 
 def parse_dotenv(dotenv_path):
@@ -61,6 +62,6 @@ def parse_args_env(parser: argparse.ArgumentParser, env_path=None):
                 else:
                     raise Exception('COULD NOT FIND ENVIRONMENT VARIABLE: {}'.format(envname))
                 # Finally, make the substitution
-                setattr(args, k, re.sub(pattern, sub, v))
+                setattr(args, k, str(Path(re.sub(pattern, sub.replace("\\","/"), v))))
 
     return args

--- a/lib/commons/rscommons/download_hand.py
+++ b/lib/commons/rscommons/download_hand.py
@@ -43,7 +43,7 @@ def download_hand(huc6, epsg, download_folder, boundary, raster_path, force_down
     else:
         safe_makedirs(download_folder)
         # Download the HAND raster
-        raster_url = os.path.join(base_url, huc6, huc6 + 'hand.tif')
+        raster_url = '/'.join(s.strip('/') for s in [base_url, huc6, huc6 + 'hand.tif'])
         log.info('HAND URL {}'.format(raster_url))
         temp_path = download_file(raster_url, download_folder)
 


### PR DESCRIPTION
@MattReimer please review these two changes to fix the windows .env file paths. I was able to download a riverscapes context project with these fixes, and I believe they should work with unix file paths as well. 