### PR TITLE
Shapely upgrade to 1.7.1

### DIFF
--- a/docs/developing/index.md
+++ b/docs/developing/index.md
@@ -36,6 +36,7 @@ Cython-0.29.21-cp38-cp38-win_amd64.whl
 GDAL-3.1.2-cp38-cp38-win_amd64.whl
 rasterio-1.1.5-cp38-cp38-win_amd64.whl
 Rtree-0.9.4-cp38-cp38-win_amd64.whl
+Shapely‑1.7.1‑cp38‑cp38‑win_amd64.whl
 ```
 
 once you've downloaded these make sure to pip install them OUTSIDE of any virtualenv (so just pip install in terminal)

--- a/lib/commons/setup.py
+++ b/lib/commons/setup.py
@@ -7,7 +7,7 @@ import re
 install_requires = [
     'geojson', 'sciencebasepy', 'requests', 'semver>=2.10.2',
     'termcolor', 'Cython>=0.29.7', 'numpy>=1.16.3', 'scipy>=1.5'
-    'argparse', 'GDAL>=3.0', 'rasterio>=1.1.5', 'Shapely==1.7.0'
+    'argparse', 'GDAL>=3.0', 'rasterio>=1.1.5', 'Shapely==1.7.1'
 ]
 
 with open("README.md", "rb") as f:

--- a/packages/brat/setup.py
+++ b/packages/brat/setup.py
@@ -6,7 +6,7 @@ import re
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
 install_requires = [
     'termcolor', 'Cython>=0.29.7', 'numpy>=1.16.3', 'scipy>=1.5'
-    'argparse', 'GDAL>=3.0', 'rasterio>=1.1.5', 'Shapely==1.7.0', 'scikit-fuzzy>=0.4.2',
+    'argparse', 'GDAL>=3.0', 'rasterio>=1.1.5', 'Shapely==1.7.1', 'scikit-fuzzy>=0.4.2',
     'rs-commons@git+https://github.com/Riverscapes/rs-commons-python@master#egg=rs-commons'
 ]
 

--- a/packages/rscontext/setup.py
+++ b/packages/rscontext/setup.py
@@ -6,7 +6,7 @@ import re
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
 install_requires = [
     'termcolor', 'Cython>=0.29.7', 'numpy>=1.16.3', 'scipy>=1.5'
-    'argparse', 'GDAL>=3.0', 'rasterio>=1.1.5', 'Shapely==1.7.0',
+    'argparse', 'GDAL>=3.0', 'rasterio>=1.1.5', 'Shapely==1.7.1',
     'rs-commons@git+https://github.com/Riverscapes/rs-commons-python@master#egg=rs-commons'
 ]
 

--- a/packages/vbet/setup.py
+++ b/packages/vbet/setup.py
@@ -6,7 +6,7 @@ import re
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
 install_requires = [
     'termcolor', 'Cython>=0.29.7', 'numpy>=1.16.3', 'scipy>=1.5',
-    'argparse', 'GDAL>=3.0', 'rasterio>=1.1.5', 'Shapely==1.7.0',
+    'argparse', 'GDAL>=3.0', 'rasterio>=1.1.5', 'Shapely==1.7.1',
     'rs-commons@git+https://github.com/Riverscapes/rs-commons-python@master#egg=rs-commons'
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ s3transfer==0.3.3
 scikit-fuzzy==0.4.2
 scipy==1.5.1
 semver==2.10.2
-Shapely==1.7.0
+Shapely==1.7.1
 six==1.15.0
 snuggs==1.4.7
 termcolor==1.1.0

--- a/scripts/bootstrap-win.sh
+++ b/scripts/bootstrap-win.sh
@@ -1,26 +1,25 @@
 #! /bin/bash
 set -eu
 
-# NOTE: this assumes you've already installed Cython, GDAL, rasterio, Rtree from 
+# NOTE: this assumes you've already installed Cython, GDAL, rasterio, Rtree and Shapely from 
 # .whl files. See ./Developer.md if you need instructions on how to do that
 
 # On OSX you must have run `brew install gdal` so that the header files are findable 
 python -m virtualenv .venv
 # Make sure pip is at a good version
 
-source ./venv/scripts/activate
+source ./venv/Scripts/activate
 
 pip --timeout=120 install \
   Cython==0.29.7 \
   numpy==1.16.3 \
-  shapely==1.7.0 \
   scipy==1.5.1
 
 # Now install everything else
-.venv/bin/pip --timeout=120 install -r requirements.txt
+.venv/Scripts/pip --timeout=120 install -r requirements.txt
 
 # Install our packages as being editable
-.venv/bin/pip install -e ./lib/commons
-.venv/bin/pip install -e ./packages/rscontext
-.venv/bin/pip install -e ./packages/vbet
-.venv/bin/pip install -e ./packages/brat
+.venv/Scripts/pip install -e ./lib/commons
+.venv/Scripts/pip install -e ./packages/rscontext
+.venv/Scripts/pip install -e ./packages/vbet
+.venv/Scripts/pip install -e ./packages/brat

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,7 +8,7 @@ python3 -m virtualenv .venv
 .venv/bin/pip --timeout=120 install \
   Cython==0.29.7 \
   numpy==1.16.3 \
-  shapely==1.7.0 \
+  shapely==1.7.1 \
   scipy==1.5.1 \
   --no-binary shapely
 


### PR DESCRIPTION
There's a problem in windows where `mapping(shapely_obj)` returns all 0.0 coordinates

The issue is that we can't have Shapely installed from PyPi when GDAL is installed from `https://www.lfd.uci.edu/~gohlke/pythonlibs/#shapely`

The instructions and bootstrap scripts have been updated but a side-effect is that we need to upgrade SHapely to 1.7.1 because 1.7.0 is not available as a wheel file