### PR TITLE
Collision prevention for parallel RSContext runs

### DIFF
--- a/lib/commons/rscommons/__init__.py
+++ b/lib/commons/rscommons/__init__.py
@@ -5,6 +5,7 @@
 from rscommons.classes.gdal_errors import initGDALOGRErrors
 from rscommons.classes.geotransform import Geotransform
 from rscommons.classes.logger import Logger
+from rscommons.classes.timer import Timer
 from rscommons.classes.loop_timer import LoopTimer
 from rscommons.classes.model_config import ModelConfig
 from rscommons.classes.progress_bar import ProgressBar

--- a/lib/commons/rscommons/classes/timer.py
+++ b/lib/commons/rscommons/classes/timer.py
@@ -1,0 +1,14 @@
+import time
+
+class Timer:
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self._start_time = time.perf_counter()
+        self._stop_time = None
+
+    def ellapsed(self):
+      self._stop_time = time.perf_counter() 
+      return self._stop_time - self._start_time

--- a/lib/commons/rscommons/download.py
+++ b/lib/commons/rscommons/download.py
@@ -127,14 +127,14 @@ def download_file(s3_url, download_folder, force_download=False):
             safe_remove_file(tmpfilepath)
             safe_remove_file(file_path_pending)
 
-        if not os.path.isfile(file_path_pending):
-            refresh_pending()
+        refresh_pending()
 
         pending_timer = Timer()
         log.info('Downloading {}'.format(s3_url))
 
         # Actual file download
-        for download_retries in range(3):
+        max_attempts = 3
+        for download_retries in range(max_attempts):
             if download_retries> 0:
                 log.warning('Download file retry: {}'.format(download_retries))
             try:
@@ -165,12 +165,12 @@ def download_file(s3_url, download_folder, force_download=False):
             except Exception as e:
                 log.debug('Error downloading file from s3 {}: \n{}'.format(s3_url, str(e)))
                 # if this is our last chance then the function must fail [0,1,2]
-                if download_retries == 2:
+                if download_retries == max_attempts -1:
                     download_cleanup() # Always clean up
                     raise e
 
         # Now copy the temporary file (retry 3 times)
-        for copy_retries in range(3):
+        for copy_retries in range(max_attempts):
             if copy_retries> 0:
                 log.warning('Copy file retry: {}'.format(copy_retries))            
             try:
@@ -183,7 +183,7 @@ def download_file(s3_url, download_folder, force_download=False):
             except Exception as e:
                 log.debug('Error copying file from temporary location {}: \n{}'.format(tmpfilepath, str(e)))
                 # if this is our last chance then the function must fail [0,1,2]
-                if copy_retries == 2:
+                if copy_retries == max_attempts -1:
                     download_cleanup() # Always clean up
                     raise e
 

--- a/lib/commons/rscommons/download.py
+++ b/lib/commons/rscommons/download.py
@@ -47,13 +47,7 @@ def download_unzip(url, download_folder, unzip_folder=None, force_download=False
 
     final_unzip_folder = unzip_folder if unzip_folder is not None else os.path.splitext(zipfilepath)[0]
 
-    try:
-        unzip(zipfilepath, final_unzip_folder, force_download, retries)
-    except Exception as e:
-        log.debug(e)
-        log.info('Waiting 5 seconds and Retrying once')
-        time.sleep(5)
-        unzip(zipfilepath, unzip_folder, force_download, retries)
+    unzip(zipfilepath, final_unzip_folder, force_download, retries)
 
     return final_unzip_folder
 
@@ -199,11 +193,18 @@ def download_file(s3_url, download_folder, force_download=False):
 
 
 def unzip(file_path, destination_folder, force_overwrite=False, retries=3):
-    """
-    Uncompress a zip archive into the specified destination folder
-    :param file_path: Full path to an existing zip archive
-    :param destination_folder: Path where the zip archive will be unzipped
-    :return: None
+    """[summary]
+
+    Args:
+        file_path: Full path to an existing zip archive
+        destination_folder: Path where the zip archive will be unzipped
+        force_overwrite (bool, optional): Force overwrite of a file if it's already there. Defaults to False.
+        retries (int, optional): Number of retries on a single file. Defaults to 3.
+
+    Raises:
+        Exception: [description]
+        Exception: [description]
+        Exception: [description]
     """
     log = Logger('Unzipper')
 
@@ -252,8 +253,12 @@ def unzip(file_path, destination_folder, force_overwrite=False, retries=3):
         zip_ref.close()
         log.info('Done')
 
-    except Exception as e:
-        log.error('Error unzipping. Cleaning up zip file and output folder')
+    except zipfile.BadZipFile as e:
+        # If the zip file is bad then we have to remove it.
+        log.error('BadZipFile. Cleaning up zip file and output folder')    
         safe_remove_file(file_path)
+        safe_remove_dir(destination_folder)
+    except Exception as e:
+        log.error('Error unzipping. Cleaning up output folder')        
         safe_remove_dir(destination_folder)
         raise Exception('Unzip error: file could not be unzipped')

--- a/lib/commons/rscommons/util.py
+++ b/lib/commons/rscommons/util.py
@@ -4,6 +4,7 @@ import gc
 import sys
 import glob
 import shutil
+import hashlib
 import os
 from math import cos, sin, asin, sqrt, radians
 from rscommons import Logger
@@ -26,6 +27,84 @@ def batch(iterable, n=1):
     for ndx in range(0, length, n):
         yield iterable[ndx:min(ndx + n, length)]
 
+
+def safe_remove_file(file_path):
+    """Remove a file without throwing an error
+
+    Args:
+        file_path ([type]): [description]
+    """
+    log = Logger("safe_remove_file")
+    try:
+        if not os.path.isfile(file_path):
+            log.warning('File not found: {}'.format(file_path))
+        os.remove(file_path)
+        log.debug('File removed: {}'.format(file_path))
+    except Exception as e:
+        log.error(str(e))
+
+
+def file_compare(file_a, file_b, md5=True):
+    """Do a file comparison, starting with file size and finishing with md5
+
+    Args:
+        file_a ([type]): [description]
+        file_b ([type]): [description]
+
+    Returns:
+        [type]: [description]
+    """
+    log = Logger("file_compare")
+    log.debug('Comparing: {} {}'.format(file_a, file_b))
+    try:
+        # If the file sizes aren't the same then there's
+        # no reason to do anything more
+        a_stats = os.stat(file_a)
+        b_stats = os.stat(file_b)
+        if a_stats.st_size != b_stats.st_size:
+            log.info('Files are NOT the same size: {:,} vs. {:,}')
+            return False
+
+        # If we want this to be a quick-compare and not do MD5 then we just
+        # do the file size and leave it at that
+        if not md5:
+            return True
+
+        with open(file_a, 'rb') as afile:
+            hasher1 = hashlib.md5()
+            buf1 = afile.read()
+            hasher1.update(buf1)
+            md5_a=(str(hasher1.hexdigest()))
+
+        with open(file_b, 'rb') as bfile:
+            hasher2 = hashlib.md5()
+            buf1 = bfile.read()
+            hasher2.update(buf1)
+            md5_b=(str(hasher2.hexdigest()))
+
+        #Compare md5
+        if(md5_a==md5_b):
+            log.info('File MD5 hashes match')
+            return True
+        else:
+            log.info('File MD5 hashes DO NOT match')
+            return False
+    except Exception as e:
+        log.error('Error comparing files: {}', str(e))
+        return False
+
+def safe_remove_dir(dir_path):
+    """Remove a directory without throwing an error
+
+    Args:
+        file_path ([type]): [description]
+    """
+    log = Logger("safe_remove_dir")
+    try:
+        shutil.rmtree(dir_path, ignore_errors=True)
+        log.debug('Directory removed: {}'.format(dir_path))
+    except Exception as e:
+        log.error(str(e))
 
 def safe_makedirs(dir_create_path):
     """safely, recursively make a directory

--- a/lib/commons/rscommons/util.py
+++ b/lib/commons/rscommons/util.py
@@ -62,7 +62,7 @@ def file_compare(file_a, file_b, md5=True):
         a_stats = os.stat(file_a)
         b_stats = os.stat(file_b)
         if a_stats.st_size != b_stats.st_size:
-            log.info('Files are NOT the same size: {:,} vs. {:,}')
+            log.debug('Files are NOT the same size: {:,} vs. {:,}')
             return False
 
         # If we want this to be a quick-compare and not do MD5 then we just

--- a/lib/commons/rscommons/util.py
+++ b/lib/commons/rscommons/util.py
@@ -84,10 +84,10 @@ def file_compare(file_a, file_b, md5=True):
 
         #Compare md5
         if(md5_a==md5_b):
-            log.info('File MD5 hashes match')
+            log.debug('File MD5 hashes match')
             return True
         else:
-            log.info('File MD5 hashes DO NOT match')
+            log.debug('File MD5 hashes DO NOT match')
             return False
     except Exception as e:
         log.error('Error comparing files: {}', str(e))

--- a/packages/rscontext/.vscode/launch.json
+++ b/packages/rscontext/.vscode/launch.json
@@ -32,6 +32,7 @@
         "{env:DOWNLOAD_FOLDER}",
         // "--temp_folder", "{env:DOWNLOAD_FOLDER}/tmp",
         // "--force",
+        // "--parallel",
         "--verbose"
       ]
     },

--- a/packages/rscontext/rscontext/rs_context.py
+++ b/packages/rscontext/rscontext/rs_context.py
@@ -319,6 +319,7 @@ def main():
     parser.add_argument('output', help='Path to the output folder', type=str)
     parser.add_argument('download', help='Temporary folder for downloading data. Different HUCs may share this', type=str)
     parser.add_argument('--force', help='(optional) download existing files ', action='store_true', default=False)
+    parser.add_argument('--parallel', help='(optional) for running multiple instances of this at the same time', action='store_true', default=False)
     parser.add_argument('--temp_folder', help='(optional) cache folder for downloading files ', type=str)
     parser.add_argument('--verbose', help='(optional) a little extra logging ', action='store_true', default=False)
 
@@ -340,7 +341,8 @@ def main():
 
     # This is a general place for unzipping downloaded files and other temporary work.
     # We use GUIDS to make it specific to a particular run of the tool to avoid unzip collisions
-    scratch_dir = args.temp_folder if args.temp_folder else os.path.join(args.download, 'scratch', 'rs_context-{}'.format(uuid.uuid4()))
+    parallel_code = "-" + uuid.uuid4() if args.parallel is True else ""
+    scratch_dir = args.temp_folder if args.temp_folder else os.path.join(args.download, 'scratch', 'rs_context{}'.format(parallel_code))
     safe_makedirs(scratch_dir)
 
     try:

--- a/packages/rscontext/rscontext/rs_context.py
+++ b/packages/rscontext/rscontext/rs_context.py
@@ -341,7 +341,7 @@ def main():
 
     # This is a general place for unzipping downloaded files and other temporary work.
     # We use GUIDS to make it specific to a particular run of the tool to avoid unzip collisions
-    parallel_code = "-" + uuid.uuid4() if args.parallel is True else ""
+    parallel_code = "-" + str(uuid.uuid4()) if args.parallel is True else ""
     scratch_dir = args.temp_folder if args.temp_folder else os.path.join(args.download, 'scratch', 'rs_context{}'.format(parallel_code))
     safe_makedirs(scratch_dir)
 


### PR DESCRIPTION
This is meant to fix #51 

- [x] make sure RSContext logs are clean
- [x] Try with and without the `--parallel` flag
- [x] Try a corrupted Zip file
- [x] Try two processes simultaneously and see if they wait