### PR TITLE
Conservation fix

### DIFF
--- a/packages/brat/sqlbrat/utils/conservation.py
+++ b/packages/brat/sqlbrat/utils/conservation.py
@@ -123,9 +123,9 @@ def calc_limited(limitations, ovc_hpe, ovc_ex, occ_ex, slope, landuse, splow, sp
     raise Exception('Unhandled dam limitation')
 
 
-def calc_opportunities(opportunities, risks, OpportunityID, occ_hpe, occ_ex, mCC_HisDep, iPC_VLowLU, iPC_HighLU):
+def calc_opportunities(opportunities, risks, RiskID, occ_hpe, occ_ex, mCC_HisDep, iPC_VLowLU, iPC_HighLU):
 
-    if OpportunityID == risks['Negligible Risk'] or OpportunityID == risks['Minor Risk']:
+    if RiskID == risks['Negligible Risk'] or RiskID == risks['Minor Risk']:
         # 'oCC_EX' Frequent or Pervasive
         # 'mCC_HisDep' <= 3
         if occ_ex >= 5 and mCC_HisDep <= 3:


### PR DESCRIPTION
@MattReimer land use intensity involves calculating the fraction of veg in each land use intensity class. This fraction is the area of veg in a particular class divided by the total area of veg in the buffer. 

But the code was summing all cells in the 100m buffer, which was summing both the existing and historic vegetation classes. This double counting of veg was suppressing the fraction of veg in each class, which in turn was causing the conservation module to never encounter veg proportions greater than 75%, needed for some logic later in BRAT. issue #102 

This should be a fairly safe fix as it changes numbers but doesn't change any code logic.