### PR TITLE
Ignore zero length features when copying features

### DIFF
--- a/lib/commons/rscommons/vector_ops.py
+++ b/lib/commons/rscommons/vector_ops.py
@@ -203,7 +203,7 @@ def copy_feature_class(in_layer_path: str, out_layer_path: str,
                 progbar.erase()  # get around the progressbar
                 log.warning('Feature with FID={} has no geometry. Skipping'.format(feature.GetFID()))
                 continue
-            if geom.GetGeometryType() == 2:
+            if geom.GetGeometryType() in VectorBase.LINE_TYPES:
                 if geom.Length() == 0.0:
                     progbar.erase()  # get around the progressbar
                     log.warning('Feature with FID={} has no Length. Skipping'.format(feature.GetFID()))

--- a/lib/commons/rscommons/vector_ops.py
+++ b/lib/commons/rscommons/vector_ops.py
@@ -203,7 +203,11 @@ def copy_feature_class(in_layer_path: str, out_layer_path: str,
                 progbar.erase()  # get around the progressbar
                 log.warning('Feature with FID={} has no geometry. Skipping'.format(feature.GetFID()))
                 continue
-
+            if geom.GetGeometryType() == 2:
+                if geom.Length() == 0.0:
+                    progbar.erase()  # get around the progressbar
+                    log.warning('Feature with FID={} has no Length. Skipping'.format(feature.GetFID()))
+                    continue
             geom.Transform(transform)
 
             # Create output Feature


### PR DESCRIPTION
Fixes #150. This change is in vector_ops, and may affect other tools, however since this operation was already excluding features with no geometry, this change is really just adding another error check.