### PR TITLE
Historic & Existing Vegetation orthogonality fix

### DIFF
--- a/lib/commons/rscommons/classes/vector_classes.py
+++ b/lib/commons/rscommons/classes/vector_classes.py
@@ -30,7 +30,7 @@ class ShapefileLayer(VectorBase):
         # layer name isn't important so we hardcode 'layer'
         super(ShapefileLayer, self).__init__(filepath, VectorBase.Drivers.Shapefile, 'layer', replace_ds_on_open=delete, allow_write=write)
         if delete is True:
-            self.delete()
+            self.delete(filepath)
 
     def create(self, geom_type: int, epsg: int = None, spatial_ref: osr.SpatialReference = None, fields: dict = None):
         """Create a shapefile and associated layer

--- a/lib/commons/rscommons/clean_nhd_data.py
+++ b/lib/commons/rscommons/clean_nhd_data.py
@@ -4,7 +4,7 @@ from osgeo import ogr
 from rscommons.science_base import get_nhdhr_url
 from rscommons.download import download_unzip
 from rscommons.filegdb import export_feature_class, copy_attributes, export_table
-from rscommons.util import safe_makedirs, safe_remove_dir
+from rscommons.util import safe_makedirs
 from rscommons.shapefile import get_geometry_union
 
 # NHDPlus HR Value Added Attributes (VAA) to be copied to the NHDFlowline feature class

--- a/lib/commons/rscommons/raster_warp.py
+++ b/lib/commons/rscommons/raster_warp.py
@@ -79,7 +79,7 @@ def raster_vrt_stitch(inrasters, outraster, epsg, clip=None, clean=False):
     #     os.remove(path_vrt)
 
 
-def raster_warp(inraster, outraster, epsg, clip=None, cutlineBlend=None):
+def raster_warp(inraster: str, outraster: str, epsg, clip=None, warp_options: dict = None):
     """
     Reproject a raster to a different coordinate system.
     :param inraster: Input dataset
@@ -87,7 +87,10 @@ def raster_warp(inraster, outraster, epsg, clip=None, cutlineBlend=None):
     :param epsg: Output spatial reference EPSG identifier
     :param log: Log file object
     :param clip: Optional Polygon dataset to clip the output.
+    :param warp_options: Extra GDALWarpOptions.
     :return: None
+
+    https://gdal.org/python/osgeo.gdal-module.html#WarpOptions
     """
 
     log = Logger('Raster Warp')
@@ -106,10 +109,12 @@ def raster_warp(inraster, outraster, epsg, clip=None, cutlineBlend=None):
     warpvrt = os.path.join(os.path.dirname(outraster), 'temp_gdal_warp_output.vrt')
 
     log.info('Performing GDAL warp to temporary VRT file.')
-    warp_options = gdal.WarpOptions(dstSRS='EPSG:{}'.format(epsg), format='vrt')
+
     if clip:
         log.info('Clipping to polygons using {}'.format(clip))
-        warp_options = gdal.WarpOptions(dstSRS='EPSG:{}'.format(epsg), format='vrt', cutlineDSName=clip, cropToCutline=True, cutlineBlend=cutlineBlend)
+        warp_options = gdal.WarpOptions(dstSRS='EPSG:{}'.format(epsg), format='vrt', cutlineDSName=clip, cropToCutline=True, **warp_options)
+    else:
+        warp_options = gdal.WarpOptions(dstSRS='EPSG:{}'.format(epsg), format='vrt', **warp_options)
 
     ds = gdal.Warp(warpvrt, inraster, options=warp_options)
 

--- a/packages/brat/scripts/build_topography.py
+++ b/packages/brat/scripts/build_topography.py
@@ -1,11 +1,9 @@
 import os
 import shutil
 from rscommons import Logger
-from rscommons.raster_warp import raster_warp
 from rscommons.science_base import get_dem_urls
 from rscommons.download_dem import download_dem
 from rscommons.geographic_raster import gdal_dem_geographic
-
 from rscommons.raster_warp import raster_vrt_stitch
 
 

--- a/packages/brat/scripts/nwm_read.py
+++ b/packages/brat/scripts/nwm_read.py
@@ -19,7 +19,6 @@ from sqlbrat.lib.flow_accumulation import flow_accumulation
 from sqlbrat.lib.flow_accumulation import flow_accum_to_drainage_area
 
 from rscommons import Logger
-from rscommons.raster_warp import raster_warp
 from rscommons.download_dem import download_dem
 from rscommons.science_base import download_shapefile_collection
 from rscommons.science_base import get_nhd_url

--- a/packages/rscontext/rscontext/vegetation.py
+++ b/packages/rscontext/rscontext/vegetation.py
@@ -1,0 +1,66 @@
+import os
+import json
+import argparse
+from osgeo import ogr
+from osgeo import osr
+from shapely.geometry import shape, mapping
+from rscommons import Logger, dotenv, get_shp_or_gpkg, ShapefileLayer
+import rasterio
+from rscommons.raster_warp import raster_warp
+
+
+def clip_vegetation(boundary_path: str, existing_veg_path: str, existing_clip_path: str, historic_veg_path: str, historic_clip_path: str, output_epsg: int):
+    """[summary]
+
+    Args:
+        boundary_path (str): Path to layer
+        existing_veg_path (str): Path to raster
+        existing_clip_path (str): Path to output raster
+        historic_veg_path (str): Path to raster
+        historic_clip_path (str): Path to output raster
+        output_epsg (int): EPSG
+    """
+    log = Logger('Vegetation Clip')
+
+    with rasterio.open(existing_veg_path) as src:
+        meta_existing = src.meta
+        log.info('Got existing veg meta: {}'.format(meta_existing['transform']))
+
+    with rasterio.open(historic_veg_path) as src:
+        meta_hist = src.meta
+        log.info('Got historic veg meta: {}'.format(meta_hist['transform']))
+
+    # 0.01% cell size difference
+    # If it's smaller than this we can force it pretty comfortably
+    tolerance = 0.0001
+
+    if (meta_existing['transform'][0] != meta_hist['transform'][0]):
+        # Sometimes the national rasters have minor projection problems. We tolerate up to a single pixel mismatch
+        msg = 'Vegetation raster cell widths do not match: existing {}, historic {}'.format(meta_existing['transform'][0], meta_hist['transform'][0])
+        if abs((meta_existing['transform'][0] - meta_hist['transform'][0]) / meta_hist['transform'][0]) > tolerance:
+            raise Exception(msg)
+        else:
+            log.warning(msg)
+
+    if (meta_existing['transform'][4] != meta_hist['transform'][4]):
+        # Sometimes the national rasters have minor projection problems. We tolerate up to a single pixel mismatch
+        msg = 'Vegetation raster cell heights do not match: existing {}, historic {}'.format(meta_existing['transform'][4], meta_hist['transform'][4])
+        if abs((meta_existing['transform'][4] - meta_hist['transform'][4]) / meta_hist['transform'][4]) > tolerance:
+            raise Exception(msg)
+        else:
+            log.warning(msg)
+
+    # The Rasters should generally line up but just in case they don't we force the outputs
+    # to both match the existing raster cell sizes
+    # https://gdal.org/python/osgeo.gdal-module.html#WarpOptions
+    warp_options = {
+        "xRes": meta_existing['transform'][0],
+        "yRes": meta_existing['transform'][4],
+        "targetAlignedPixels": True,
+        "cutlineBlend": 2
+    }
+    # Now do the raster warp
+    raster_warp(existing_veg_path, existing_clip_path, output_epsg, clip=boundary_path, warp_options=warp_options)
+    raster_warp(historic_veg_path, historic_clip_path, output_epsg, clip=boundary_path, warp_options=warp_options)
+
+    log.info('Complete')


### PR DESCRIPTION
This fixes issues to do with the national projects having vegetation rasters that don't quite line up

Obviously the biggest fix is to update the national project (which has been done see #161)

Since the new rasters are not WGS84 we are going to reproject them for RS_context. This should address #154  and #156 