### PR TITLE
Confinement improved indexing

### DIFF
--- a/packages/confinement/confinement/confinement.py
+++ b/packages/confinement/confinement/confinement.py
@@ -324,7 +324,6 @@ def confinement(huc: int, flowlines_orig: Path, channel_area_orig: Path, confini
 
     with GeopackageLayer(output_gpkg, layer_name=LayerTypes['CONFINEMENT'].sub_layers["CONFINEMENT_BUFFERS"].rel_path, write=True) as lyr:
         lyr.create(ogr.wkbPolygon, spatial_ref=srs)
-        lyr.ogr_layer.CreateField(field_lookup['level_path'])
 
     with GeopackageLayer(intermediates_gpkg, layer_name=LayerTypes['INTERMEDIATES'].sub_layers["SPLIT_POINTS"].rel_path, write=True) as lyr:
         lyr.create(ogr.wkbPoint, spatial_ref=srs)
@@ -449,7 +448,7 @@ def confinement(huc: int, flowlines_orig: Path, channel_area_orig: Path, confini
                 log.warning(
                     "Invalid buffer polygon with level path: {}".format(level_path))
                 continue
-            buff_lyr.create_feature(geom_channel_buffer, attributes={'level_path': level_path})
+            buff_lyr.create_feature(geom_channel_buffer)
 
             # Split the Buffer by the flowline
             start = nearest_points(

--- a/packages/confinement/confinement/confinement.py
+++ b/packages/confinement/confinement/confinement.py
@@ -310,14 +310,12 @@ def confinement(huc: int, flowlines_orig: Path, channel_area_orig: Path, confini
 
     with sqlite3.connect(output_gpkg) as conn:
         curs = conn.cursor()
-        curs.execute(
-            'CREATE INDEX IF NOT EXISTS dgo_levelpath ON confinement_dgos (level_path)')
-        curs.execute(
-            'CREATE INDEX IF NOT EXISTS igo_levelpath ON confinement_igos (level_path)')
-        curs.execute(
-            'CREATE INDEX IF NOT EXISTS dgo_seg_distance ON confinement_dgos (seg_distance)')
-        curs.execute(
-            'CREATE INDEX IF NOT EXISTS igo_seg_distance ON confinement_igos (seg_distance)')
+        curs.execute('CREATE INDEX IF NOT EXISTS dgo_levelpath_seg_distance ON confinement_dgos (level_path, seg_distance)')
+        curs.execute('CREATE INDEX IF NOT EXISTS igo_levelpath_seg_distance ON confinement_igos (level_path, seg_distance)')
+        curs.execute('CREATE INDEX IF NOT EXISTS buffers_levelpath ON confinement_buffers (level_path)')
+        curs.execute('CREATE INDEX IF NOT EXISTS ratio_levelpath ON confinement_ratio (level_path)')
+        curs.execute('CREATE INDEX IF NOT EXISTS raw_levelpath ON confinement_raw (level_path)')
+        curs.execute('CREATE INDEX IF NOT EXISTS margins_levelpath ON confining_margins (level_path, side)')
         conn.commit()
 
     with GeopackageLayer(intermediates_gpkg, layer_name=LayerTypes['INTERMEDIATES'].sub_layers["CONFINEMENT_BUFFER_SPLIT"].rel_path, write=True) as lyr:

--- a/packages/confinement/confinement/confinement.py
+++ b/packages/confinement/confinement/confinement.py
@@ -312,7 +312,6 @@ def confinement(huc: int, flowlines_orig: Path, channel_area_orig: Path, confini
         curs = conn.cursor()
         curs.execute('CREATE INDEX IF NOT EXISTS dgo_levelpath_seg_distance ON confinement_dgos (level_path, seg_distance)')
         curs.execute('CREATE INDEX IF NOT EXISTS igo_levelpath_seg_distance ON confinement_igos (level_path, seg_distance)')
-        curs.execute('CREATE INDEX IF NOT EXISTS buffers_levelpath ON confinement_buffers (level_path)')
         curs.execute('CREATE INDEX IF NOT EXISTS ratio_levelpath ON confinement_ratio (level_path)')
         curs.execute('CREATE INDEX IF NOT EXISTS raw_levelpath ON confinement_raw (level_path)')
         curs.execute('CREATE INDEX IF NOT EXISTS margins_levelpath ON confining_margins (level_path, side)')
@@ -450,7 +449,7 @@ def confinement(huc: int, flowlines_orig: Path, channel_area_orig: Path, confini
                 log.warning(
                     "Invalid buffer polygon with level path: {}".format(level_path))
                 continue
-            buff_lyr.create_feature(geom_channel_buffer)
+            buff_lyr.create_feature(geom_channel_buffer, attributes={'level_path': level_path})
 
             # Split the Buffer by the flowline
             start = nearest_points(


### PR DESCRIPTION
**I HAVE NOT RUN THIS CODE. NEEDS TESTING.**

Just tweaked a few of the indexes and added a couple. Some high level comments:

I've proposed [composite indexes](https://www.tutorialspoint.com/sqlite/sqlite_indexes.htm) for levelpath and sequence. This works because we rarely, if ever, query sequence without also specifying a levelpath. Note that this composite index also helps if you are just querying levelpath without specifying a sequence. (But it is useless if you want to query sequence without specifying levelpath. Order matters.)

Note that I used a composite for the confining margins with levelpath and side. I think this presumes you symbolise the sides differently. Might help Q display the symbology quicker.