### PR TITLE
exclude reaches with da = 0

### DIFF
--- a/packages/hydro/hydro/utils/hydrology.py
+++ b/packages/hydro/hydro/utils/hydrology.py
@@ -66,8 +66,8 @@ def hydrology(gpkg_path: str, prefix: str, huc: str):
         log.info(f'Reach drainage area attribute conversion factor = {drainage_conversion_factor}')
 
     # Load the discharges for each reach
-    reaches = load_attributes(gpkg_path, ['DrainArea'], '(DrainArea IS NOT NULL)')
-    dgos = load_dgo_attributes(gpkg_path, ['DrainArea'], '(DrainArea IS NOT NULL)')
+    reaches = load_attributes(gpkg_path, ['DrainArea'], '(DrainArea IS NOT NULL AND DrainArea > 0)')
+    dgos = load_dgo_attributes(gpkg_path, ['DrainArea'], '(DrainArea IS NOT NULL AND DrainArea > 0)')
     log.info(f'{len(reaches):,} reaches loaded with valid drainage area values')
 
     # Calculate the discharges for each reach


### PR DESCRIPTION
some of the hydro equations have negative exponents, so reaches with da = 0 were causing it to fail.

These equations are the ones that are garbage, but if we want it to run without failing we need to exclude these reaches (which I think is still fine even when equations are good).