### PR TITLE
new project type of RSContext NZ

### DIFF
--- a/lib/riverscapes/riverscapes/projectTypeTool/projectTypes.json
+++ b/lib/riverscapes/riverscapes/projectTypeTool/projectTypes.json
@@ -1181,5 +1181,27 @@
     "url": null,
     "machineName": "NZNational",
     "state": "ACTIVE"
+  },
+  {
+    "name": "Riverscapes Context (New Zealand)",
+    "summary": null,
+    "description": "Riverscapes Context project type for New Zealand. Contains hydrography and topography data for individual New Zealand watersheds.",
+    "meta": [
+        { 
+          "key": "Resolution",
+          "value": "Reach,Cell"
+        },
+        { 
+          "key": "Extent",
+          "value": "Network"
+        },
+        {
+          "key": "Riverscapes Project Class",
+          "value": "Model Output"
+        }
+       ],
+    "url": null,
+    "machineName": "RSContextNZ",
+    "state": "ACTIVE"
   }
 ]


### PR DESCRIPTION
New Project type for RSContext in new zealand. This will allow us to have unique business logic and symbology in New Zealand.