### PR TITLE
MetaData improvements

### DIFF
--- a/lib/commons/rscommons/classes/rs_project.py
+++ b/lib/commons/rscommons/classes/rs_project.py
@@ -723,11 +723,10 @@ class RSProject:
         There are similarities to XPath but they are not the same. The idea is that you can use this path to find the
         same node in another XML document. This is useful for things like linking to external data sources.
         """
-        path_arr = [(lyrnod_in.tag, lyrnod_in.attrib['id'] if 'id' in lyrnod_in.attrib else None)]
+        path_arr = []
         curr_node = lyrnod_in
         try:
-            while xml_builder.find_element_parent(curr_node) is not None:
-                curr_node = xml_builder.find_element_parent(curr_node)
+            while curr_node is not None:
                 if 'id' in curr_node.attrib:
                     item2 = curr_node.attrib['id']
                 elif 'lyrName' in curr_node.attrib:
@@ -735,6 +734,7 @@ class RSProject:
                 else:
                     item2 = None
                 path_arr.append((curr_node.tag, item2))
+                curr_node = xml_builder.find_element_parent(curr_node)
         except Exception:
             # find_element_parent will throw an exception if it can't find a parent.
             pass

--- a/lib/commons/rscommons/classes/rs_project.py
+++ b/lib/commons/rscommons/classes/rs_project.py
@@ -632,7 +632,9 @@ class RSProject:
                     self.add_metadata([RSMeta('Watershed', watershed_node.text)])
 
             # Define our default, generic warehouse and project meta
-            projmeta: List[RSMeta] = self.meta_keys_ext(in_prj.get_metadata(), RSMetaExt.PROJECT)
+            projmeta: Dict[str, RSMeta] = self.meta_keys_ext(in_prj.get_metadata(), RSMetaExt.PROJECT)
+            if 'DEXID' not in projmeta and warehouse_id is not None:
+                projmeta['DEXID'] = RSMeta("DEXID", warehouse_id, RSMetaTypes.GUID, meta_ext=RSMetaExt.WAREHOUSE)
 
             projtype = None
             # look for any valid mappings and move metadata into them


### PR DESCRIPTION
These are two very small fixes to do with 

- #1152

1. Add a special `DEXID` metadata item so that the data exchange will have a reliable project id to use going forward for when we want to know the originator project

It looks like this:

```xml
<Meta name="DEXID" ext="warehouse" type="guid">2f57f63c-0c9a-42bb-8f39-18b420806860</Meta>
```

3. Fixes a bug in `rsxpath` so that we get the proper `lyrName` at the end

```
OLD:
2f57f63c-0c9a-42bb-8f39-18b420806860:Project/Realizations/Realization#REALIZATION1/Datasets/Geopackage#HYDRODERIVATIVES/Layers/Vector

NEW:

2f57f63c-0c9a-42bb-8f39-18b420806860:Project/Realizations/Realization#REALIZATION1/Datasets/Geopackage#HYDRODERIVATIVES/Layers/Vector#network_intersected
```