### PR TITLE
Add RSContext local setup documentation

### DIFF
--- a/docs/docs/rscontext/data.mdx
+++ b/docs/docs/rscontext/data.mdx
@@ -3,6 +3,10 @@ title: Data
 position: 3
 ---
 
+This page describes the **output layers** produced by RSContext for a given watershed. These are the datasets you'll find in a completed RSContext project, whether you [download a pre-built project](https://data.riverscapes.net) or [run RSContext locally](./running-locally).
+
+RSContext takes national-scale datasets, clips them to your watershed boundary, and packages them into a standardized Riverscapes project. The layers below are derived from publicly available sources, processed and organized for use with other Riverscapes tools.
+
 :::info
 This documentation describes the RSContext model as implemented for the **United States**. Similar models exist for other regions, such as New Zealand, France, and Italy. While the overarching concept—retrieving publicly available river-related data—is consistent across jurisdictions, the specific algorithms are tailored to each country to accommodate differences in government data providers.
 :::
@@ -43,11 +47,11 @@ Hillshade raster generated using the [gdal_dem](https://gdal.org/programs/gdalde
 
 <h3><a name="HDIST">Historic Disturbance</a></h3>
 
-[LandFire](https://landfire.gov) Historic Disturbance (HDst) raster: The latest 10 years of Annual Disturbance products are used to identify disturbance year, type, and severity. Starting with LF Remap, HDist replaces VDist from previous LF versions incorporating pre-disturbance vegetation logic (based on disturbance year and vegetation type). The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
+[LandFire](https://landfire.gov) Historic Disturbance (HDist) raster: The latest 10 years of Annual Disturbance products are used to identify disturbance year, type, and severity. Starting with LF Remap, HDist replaces VDist from previous LF versions incorporating pre-disturbance vegetation logic (based on disturbance year and vegetation type). The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
 
 <h3><a name="FDIST">Fuel Disturbance</a></h3>
 
-[LandFire](https://landfire.gov) Fuel Disturbance (FDst) raster: The latest 10 years of Annual Disturbance products representing disturbance year and original disturbance code. FDist was a refinement of VDist in LF 1.x products and is a refinement of Historical Disturbance in LF Remap to more accurately represent disturbance scenarios within the fuels environment. The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
+[LandFire](https://landfire.gov) Fuel Disturbance (FDist) raster: The latest 10 years of Annual Disturbance products representing disturbance year and original disturbance code. FDist was a refinement of VDist in LF 1.x products and is a refinement of Historical Disturbance in LF Remap to more accurately represent disturbance scenarios within the fuels environment. The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
 
 <h3><a name="FCCS">Fuel Characteristic Classification System</a></h3>
 
@@ -63,7 +67,7 @@ Hillshade raster generated using the [gdal_dem](https://gdal.org/programs/gdalde
 
 <h3><a name="SCLASS">Succession Classes</a></h3>
 
-[LandFire](https://landfire.gov) SCla raster: Current vegetation conditions with respect to vegetation species composition, cover, and height ranges of successional states occurring within each biophysical setting. The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
+[LandFire](https://landfire.gov) SClass raster: Current vegetation conditions with respect to vegetation species composition, cover, and height ranges of successional states occurring within each biophysical setting. The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
 
 ---
 
@@ -81,7 +85,7 @@ Hillshade raster generated using the [gdal_dem](https://gdal.org/programs/gdalde
 
 <h3><a name="OWNERSHIP"></a> <a name="Ownership">Land Ownership</a></h3>
 
-Land ownership obtained from the [Bureau of Management (BLM) Land Surface Agency](https://catalog.data.gov/dataset/blm-national-surface-management-agency-area-polygons-national-geospatial-data-asset-ngda). A single ShapeFile was downloaded and then pre-processed to remove invalid geometries and other irregularities.
+Land ownership obtained from the [Bureau of Land Management (BLM) Surface Management Agency](https://gbp-blm-egis.hub.arcgis.com/datasets/6bf2e737c59d4111be92420ee5ab0b46/about). A single geodatabase was downloaded and then converted to shapefile, pre-processed to remove invalid geometries and other irregularities.
 
 <h3><a name="FAIRMARKETVALUE">Fair Market Value</a></h3>
 

--- a/docs/docs/rscontext/index.mdx
+++ b/docs/docs/rscontext/index.mdx
@@ -6,13 +6,22 @@ sidebar_position: 1
 ---
 
 
-The Riverscapes Context Tool provides watershed-scale, ready-to-use contextual data, optimized for use with other Riverscapes tools. 
+The Riverscapes Context Tool provides watershed-scale, ready-to-use contextual data, optimized for use with other Riverscapes tools.
 
-It gathers key nationally available datasets, processes them for an area of interest, and organizes them into a Riverscapes project. Instead of manually retrieving datasets from multiple sources, mosaicking DEM tiles, or clipping data to watershed boundaries—all of which can introduce errors—the Riverscapes Context Tool automates the process. 
+It gathers key nationally available datasets, processes them for an area of interest, and organizes them into a Riverscapes project. Instead of manually retrieving datasets from multiple sources, mosaicking DEM tiles, or clipping data to watershed boundaries—all of which can introduce errors—the Riverscapes Context Tool automates the process.
 
-The resulting data can be used directly or as inputs to other Riverscapes tools, ensuring consistency across projects and saving significant setup time. 
+The resulting data can be used directly or as inputs to other Riverscapes tools, ensuring consistency across projects and saving significant setup time.
 
-See the [Data section](./data) for a complete listing of the layers produced for the United States Riverscapes Context tool. 
+## How to Get RSContext Data
+
+There are two ways to get RSContext data for your watershed:
+
+| Approach | Best for | What's involved |
+|----------|----------|-----------------|
+| **Download a pre-built project** | Most users | Browse the [Data Exchange](https://data.riverscapes.net), find your watershed, download. Ready to use. |
+| **Run RSContext locally** | Developers, new watersheds, custom runs | Download ~50-100GB of national datasets once, then generate projects for any HUC. See [Running Locally](./running-locally). |
+
+See [Data](./data) for a complete listing of the layers included in RSContext projects.
 
 ## Resources
 
@@ -24,7 +33,7 @@ See the [Data section](./data) for a complete listing of the layers produced for
       toolUrl: "https://data.riverscapes.net/s?type=Project&projectTypeId=rscontext&view=map&geo=56.915746141861376%2C11.171228562178229%2C1.0160873547098384",
       logoUrl: "https://cdn.riverscapes.net/icons/products/data-exchange/data-exchange.svg",
     },
-  
+
     {
       title: "Latest Version Change Log",
       description: "Release notes tracking changes, bug fixes and issues.",

--- a/docs/docs/rscontext/running-locally.mdx
+++ b/docs/docs/rscontext/running-locally.mdx
@@ -1,0 +1,304 @@
+---
+title: Running Locally
+position: 4
+description: How to download and set up national datasets for running Riverscapes Context locally
+---
+
+# Running RSContext Locally
+
+:::tip Most users don't need this page
+If you just want to **use** Riverscapes Context data for your watershed, download a pre-built project from the [Riverscapes Data Exchange](https://data.riverscapes.net). The steps below are only needed if you want to **run RSContext yourself** to generate new projects.
+:::
+
+This guide explains how to set up your environment to run RSContext locally. RSContext takes national-scale datasets as inputs and clips/processes them for a specific watershed (HUC). You download these large datasets once, then reuse them for any watershed you want to process.
+
+**The workflow is:**
+1. Download national datasets (this page) → one-time setup
+2. Run RSContext for your HUC → clips national data to your watershed
+3. Use the outputs → described in [Data](./data)
+
+:::info
+This guide covers US datasets. Other regions (New Zealand, Italy, France) have different data sources and are covered in their respective tool documentation.
+:::
+
+## Prerequisites Overview
+
+Running RSContext requires several national datasets totaling **50-100+ GB**. These are the **input** datasets that RSContext will clip and process for your specific watershed. You download them once and reuse them across multiple HUC analyses.
+
+## Folder Structure
+
+Set up your data directories with this structure:
+
+```
+NATIONAL_PROJECT/                    # National datasets (download once)
+├── landfire/
+│   └── 240/                         # Pass this folder path to rscontext
+│       ├── LC23_EVT_240.tif         # Existing vegetation (LF 2023)
+│       ├── LC20_BPS_220.tif         # Historic vegetation (LF 2020)
+│       ├── LC23_EVC_240.tif         # Vegetation cover
+│       ├── LC23_EVH_240.tif         # Vegetation height
+│       └── ...                      # Other LANDFIRE layers (see table below)
+├── ownership/
+│   ├── surface_management_agency.shp
+│   └── FairMarketValue.tif
+├── ecoregions/
+│   └── us_eco_l4.shp
+├── political_boundaries/
+│   ├── states.shp                   # or cb_YYYY_us_state_500k.shp
+│   └── counties.shp                 # or cb_YYYY_us_county_500k.shp
+├── geology/
+│   └── SGMC_Geology.shp
+└── prism/                           # Climate data - pass this folder path
+    └── *.bil                        # PRISM BIL format rasters
+
+DATA_ROOT/                           # Working data
+├── national_dams/
+│   └── usace_national_dams.gpkg     # National Inventory of Dams
+├── nhd/
+│   └── nhdplusv2.gpkg               # NHDPlus V2 (1:100,000)
+└── rs_context/                      # Output projects
+    └── <HUC_ID>/
+
+DOWNLOAD_FOLDER/                     # Temporary download cache
+```
+
+## Environment Variables
+
+Create a `.env` file in each package directory (or your shell config):
+
+```bash
+NATIONAL_PROJECT=/path/to/NationalDatasets
+DATA_ROOT=/path/to/data
+DOWNLOAD_FOLDER=/path/to/downloads
+```
+
+## Required Input Datasets
+
+The following national datasets must be downloaded and organized before running RSContext. Each section includes download links and setup instructions.
+
+### 1. Vegetation Data (LANDFIRE)
+
+LANDFIRE provides vegetation rasters for the entire US. RSContext expects a **folder** containing these rasters with specific filenames.
+
+**Required files and versions:**
+
+| Dataset | Description | Expected Filename | Download Version |
+|---------|-------------|-------------------|------------------|
+| **EVT** (Existing Vegetation Type) | Current vegetation | `LC23_EVT_240.tif` | LF 2023 |
+| **BPS** (Biophysical Settings) | Historic/potential vegetation | `LC20_BPS_220.tif` | LF 2020 |
+| **EVC** (Existing Vegetation Cover) | Canopy cover percentage | `LC23_EVC_240.tif` | LF 2023 |
+| **EVH** (Existing Vegetation Height) | Vegetation height | `LC23_EVH_240.tif` | LF 2023 |
+| **HDist** (Historic Disturbance) | Disturbance history | `LC23_HDist_240.tif` | LF 2023 |
+| **FDist** (Fuel Disturbance) | Fuel disturbance | `LC23_FDist_240.tif` | LF 2023 |
+| **FCCS** (Fuel Classification) | Fuel characteristics | `LC23_FCCS_240.tif` | LF 2023 |
+| **VCC** (Vegetation Condition) | Vegetation condition class | `LC23_VCC_240.tif` | LF 2023 |
+| **VDep** (Vegetation Departure) | Departure from historic | `LC23_VDep_240.tif` | LF 2023 |
+| **SClass** (Succession Classes) | Succession class | `LC23_SClass_240.tif` | LF 2023 |
+
+:::caution Different versions required
+BPS (Biophysical Settings) represents historic/potential vegetation and is only updated periodically - LF 2020 is currently the latest available. All other products use LF 2023. This is intentional - see `LANDFIRE_INPUTS` in `rs_context.py` for the authoritative list of expected filenames.
+:::
+
+**Download:**
+1. Go to [LANDFIRE Full Extent Downloads](https://landfire.gov/data/FullExtentDownloads?field_region_id_target_id=4) (filtered to CONUS)
+2. Download each product at the version specified in the table above
+3. Extract all zip files to `NATIONAL_PROJECT/landfire/240/`
+4. Rename the extracted `.tif` files to match the expected filenames
+
+**Renaming example:**
+The downloaded zip extracts to a file like `LC23_EVT_240.tif` - this should already match the expected name. If names differ, rename to match the "Expected Filename" column above.
+
+```bash
+# Example: if extracted file has a different name
+mv "LF2023_EVT_240_CONUS/LC23_EVT_240.tif" LC23_EVT_240.tif
+```
+
+:::tip Checking expected filenames
+The expected LANDFIRE filenames are defined in `packages/rscontext/rscontext/rs_context.py` in the `LANDFIRE_INPUTS` dictionary at the top of the file. When LANDFIRE releases new versions, that config will be updated.
+:::
+
+---
+
+### 2. Land Ownership
+
+**Surface Management Agency:**
+1. Go to [BLM National Surface Management Agency](https://gbp-blm-egis.hub.arcgis.com/datasets/6bf2e737c59d4111be92420ee5ab0b46/about) or use the [direct download link](https://www.arcgis.com/sharing/rest/content/items/6bf2e737c59d4111be92420ee5ab0b46/data)
+2. Download the geodatabase
+3. Convert to shapefile:
+
+```bash
+ogr2ogr -f "ESRI Shapefile" \
+  $NATIONAL_PROJECT/ownership/surface_management_agency.shp \
+  /path/to/SMA_WM.gdb SurfaceManagementAgency \
+  -t_srs 'EPSG:4269' \
+  -select 'ADMIN_AGENCY_CODE'
+```
+
+**Fair Market Value:**
+1. Go to [PLACES Lab - US Land Values](https://placeslab.org/fmv_usa/)
+2. Or direct from [Dryad Dataset](https://datadryad.org/stash/dataset/doi:10.5061/dryad.np5hqbzq9)
+3. Download `places_fmv_pnas_dryad.zip`
+4. Extract to `NATIONAL_PROJECT/ownership/FairMarketValue.tif`
+
+---
+
+### 3. Ecoregions
+
+1. Go to [EPA Ecoregions](https://www.epa.gov/eco-research/level-iii-and-iv-ecoregions-continental-united-states)
+2. Download the Level IV ecoregions shapefile (includes Level III)
+3. Extract to `NATIONAL_PROJECT/ecoregions/` (file will be `us_eco_l4.shp`)
+
+---
+
+### 4. Political Boundaries
+
+**State and County boundaries from US Census Bureau:**
+
+1. Go to [Census Bureau Cartographic Boundary Files](https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html)
+2. Download the latest year's 500k resolution shapefiles:
+   - States: `cb_YYYY_us_state_500k.zip`
+   - Counties: `cb_YYYY_us_county_500k.zip`
+3. Extract to `NATIONAL_PROJECT/political_boundaries/`
+
+:::tip
+Use the most recent year available. The filenames include the year (e.g., `cb_2024_us_state_500k.shp`).
+:::
+
+---
+
+### 5. Climate Data (PRISM)
+
+1. Go to [PRISM Climate Group](https://prism.oregonstate.edu/)
+2. Download precipitation normals at 800m resolution
+3. Place in `NATIONAL_PROJECT/prism/`
+
+---
+
+### 6. Geology
+
+1. Go to [USGS State Geologic Map Compilation](https://www.sciencebase.gov/catalog/item/5888bf4fe4b05ccb964bab9a)
+2. Download `SGMC_Geology.zip`
+3. Extract to `NATIONAL_PROJECT/geology/`
+
+---
+
+### 7. National Dams
+
+The USACE National Inventory of Dams is required.
+
+1. Go to [USACE National Inventory of Dams](https://nid.sec.usace.army.mil/)
+2. Download the national dataset
+3. Convert to GeoPackage and place at `DATA_ROOT/national_dams/usace_national_dams.gpkg`
+
+---
+
+### 8. NHDPlus V2 (1:100,000)
+
+RSContext requires the NHDPlus V2 dataset (medium resolution, 1:100,000 scale). This is **not** auto-downloaded.
+
+1. Go to [EPA NHDPlus](https://www.epa.gov/waterdata/nhdplus-national-hydrography-dataset-plus)
+2. Download the NHDPlusV2 data for your region
+3. Convert to GeoPackage and place at `DATA_ROOT/nhd/nhdplusv2.gpkg`
+
+:::info
+RSContext also downloads NHDPlus HR (high resolution, 1:24,000) automatically for each HUC during processing. But the V2 dataset above is a required input.
+:::
+
+---
+
+## Verification Checklist
+
+Before running rscontext, verify you have:
+
+- [ ] LANDFIRE folder with vegetation rasters (EVT, BPS, EVC, EVH, etc.)
+- [ ] Surface management agency shapefile
+- [ ] Fair market value raster
+- [ ] Ecoregions shapefile (`us_eco_l4.shp`)
+- [ ] State boundaries shapefile
+- [ ] County boundaries shapefile
+- [ ] Geology shapefile (SGMC)
+- [ ] PRISM folder with climate data (BIL format)
+- [ ] National dams GeoPackage
+- [ ] NHDPlusV2 GeoPackage
+- [ ] Environment variables set (NATIONAL_PROJECT, DATA_ROOT, DOWNLOAD_FOLDER)
+
+---
+
+## Finding Your Watershed (HUC)
+
+To find the HUC code for your area of interest:
+
+1. Go to [USGS Watershed Boundary Dataset](https://water.usgs.gov/wsc/map_index.html)
+2. Click on the map to find your watershed
+3. Note the HUC code (8 or 10 digit)
+
+Common test HUCs:
+- `17060304` - Asotin Creek, WA (small, good for testing)
+- `17100202` - Example from documentation
+
+---
+
+## Running with VS Code
+
+The easiest way to run RSContext is using the pre-configured VS Code launch configuration.
+
+1. Create a `.env` file in `packages/rscontext/` with your paths:
+
+```bash
+NATIONAL_PROJECT=/path/to/NationalDatasets
+DATA_ROOT=/path/to/data
+DOWNLOAD_FOLDER=/path/to/downloads
+```
+
+2. Open `packages/rscontext` in VS Code
+3. Press F5 or use **Run > Start Debugging**
+4. Select the "RS Context" configuration
+5. Enter a HUC ID when prompted (e.g., `17060304` for Asotin Creek)
+
+The launch configuration reads paths from your `.env` file and passes all required arguments automatically.
+
+---
+
+## Running from Command Line
+
+You can also run RSContext directly from the terminal. This requires passing all arguments in order:
+
+```bash
+source .venv/bin/activate
+cd packages/rscontext
+
+python -m rscontext.rs_context <HUC_ID> \
+  $NATIONAL_PROJECT/landfire/240 \
+  $NATIONAL_PROJECT/ownership/surface_management_agency.shp \
+  $NATIONAL_PROJECT/ownership/FairMarketValue.tif \
+  $NATIONAL_PROJECT/ecoregions/us_eco_l4.shp \
+  $NATIONAL_PROJECT/political_boundaries/<states_shapefile>.shp \
+  $NATIONAL_PROJECT/political_boundaries/<counties_shapefile>.shp \
+  $NATIONAL_PROJECT/geology/SGMC_Geology.shp \
+  $NATIONAL_PROJECT/prism \
+  $DATA_ROOT/national_dams/usace_national_dams.gpkg \
+  $DATA_ROOT/nhd/nhdplusv2.gpkg \
+  $DATA_ROOT/rs_context/<HUC_ID> \
+  $DOWNLOAD_FOLDER \
+  --verbose
+```
+
+:::note
+Replace `<states_shapefile>` and `<counties_shapefile>` with the actual filenames you downloaded (e.g., `cb_2024_us_state_500k`).
+:::
+
+**Arguments in order:**
+1. HUC ID (e.g., `17060304`)
+2. LANDFIRE folder
+3. Ownership shapefile
+4. Fair market value raster
+5. Ecoregions shapefile
+6. States shapefile
+7. Counties shapefile
+8. Geology shapefile
+9. PRISM folder
+10. National dams GeoPackage
+11. NHDPlusV2 GeoPackage
+12. Output folder
+13. Download/temp folder
+

--- a/packages/rscontext/docs/data.md
+++ b/packages/rscontext/docs/data.md
@@ -37,11 +37,11 @@ Hillshade raster generated using the [gdal_dem](https//gdal.org/programs/gdaldem
 
 <h2><a name="HDIST">Historic Disturbance</a></h2>
 
-[LandFire](https//landfire.gov) Historic Disturbance (HDst) raster: The latest 10 years of Annual Disturbance products are used to identify disturbance year, type, and severity. Starting with LF Remap, HDist replaces VDist from previous LF versions incorporating pre-disturbance vegetation logic (based on disturbance year and vegetation type). The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
+[LandFire](https//landfire.gov) Historic Disturbance (HDist) raster: The latest 10 years of Annual Disturbance products are used to identify disturbance year, type, and severity. Starting with LF Remap, HDist replaces VDist from previous LF versions incorporating pre-disturbance vegetation logic (based on disturbance year and vegetation type). The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
 
 <h2><a name="FDIST">Fuel Disturbance</a></h2>
 
-[LandFire](https//landfire.gov) Fuel Disturbance (FDst) raster: The latest 10 years of Annual Disturbance products representing disturbance year and original disturbance code. FDist was a refinement of VDist in LF 1.x products and is a refinement of Historical Disturbance in LF Remap to more accurately represent disturbance scenarios within the fuels environment. The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
+[LandFire](https//landfire.gov) Fuel Disturbance (FDist) raster: The latest 10 years of Annual Disturbance products representing disturbance year and original disturbance code. FDist was a refinement of VDist in LF 1.x products and is a refinement of Historical Disturbance in LF Remap to more accurately represent disturbance scenarios within the fuels environment. The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
 
 <h2><a name="FCCS">Fuel Characteristic Classification System</a></h2>
 
@@ -57,13 +57,13 @@ Hillshade raster generated using the [gdal_dem](https//gdal.org/programs/gdaldem
 
 <h2><a name="SCLASS">Succession Classes</a></h2>
 
-[LandFire](https//landfire.gov) SCla raster: Current vegetation conditions with respect to vegetation species composition, cover, and height ranges of successional states occurring within each biophysical setting. The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
+[LandFire](https//landfire.gov) SClass raster: Current vegetation conditions with respect to vegetation species composition, cover, and height ranges of successional states occurring within each biophysical setting. The source is a single raster for the entire nation that is downloaded and then clipped to the riverscapes project extent.
 
 ## Land Management
 
 <h2><a name="Ownership">Land Ownership</a></h2>
 
-Land ownership obtained from the [Bureau of Management (BLM) Land Surface Agency](https//catalog.data.gov/dataset/blm-national-surface-management-agency-area-polygons-national-geospatial-data-asset-ngda). A single ShapeFile was downloaded and then pre-processed to remove invalid geometries and other irregularities.
+Land ownership obtained from the [Bureau of Land Management (BLM) Surface Management Agency](https://gbp-blm-egis.hub.arcgis.com/datasets/6bf2e737c59d4111be92420ee5ab0b46/about). A single geodatabase was downloaded and then converted to shapefile, pre-processed to remove invalid geometries and other irregularities.
 
 <h2><a name="FAIRMARKETVALUE">Fair Market Value</a></h2>
 

--- a/packages/rscontext/docs/index.md
+++ b/packages/rscontext/docs/index.md
@@ -16,7 +16,7 @@ The geospatial layers that the tool collects are:
   - Existing vegetation (class, name) from which an existing riparian layer is derived
   - Historic vegetation (name) from which a historic riparian layer is derived
 - **Land Management**:
-  - Land ownership/agency from [BLM Land Surface Management Agency Polygons](https://landscape.blm.gov/geoportal/catalog/search/resource/details.page?uuid=%7B2A8B8906-7711-4AF7-9510-C6C7FD991177%7D)
+  - Land ownership/agency from [BLM Surface Management Agency](https://gbp-blm-egis.hub.arcgis.com/datasets/6bf2e737c59d4111be92420ee5ab0b46/about)
   - Fair market value from [PLACES Lab](https://placeslab.org/fmv_usa/), Department of Earth & Environment, Boston University
 - **Ecoregions**:
   - level 1, 2, and 3 Ecoregions from the [EPA](https://www.epa.gov/eco-research/ecoregions)


### PR DESCRIPTION
## Summary

Adds documentation for running RSContext locally with downloaded national datasets.

## Changes

- **New:** `running-locally.mdx` - Complete guide for downloading national datasets (LANDFIRE, ecoregions, geology, etc.) and running RSContext locally
- **Updated:** `index.mdx` - Added "How to Get RSContext Data" section showing two approaches (download pre-built vs run locally)
- **Updated:** `data.mdx` - Added intro paragraph explaining these are output layers
- **Fixed:** LANDFIRE abbreviations in layer descriptions (HDst→HDist, FDst→FDist, SCla→SClass)
- **Fixed:** BLM Surface Management Agency URL

  ## Note

  This documentation complements the code fixes in [PR #1260](https://github.com/Riverscapes/riverscapes-tools/pull/1260) (fix rscontext issues with current national datasets).