### PR TITLE
hide all the vscode subfolders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,4 @@ dmypy.json
 .pyre/
 
 # VS Code auto-generated workspace settings (python-envs extension)
-.vscode/settings.json
+**/.vscode/settings.json


### PR DESCRIPTION
@MattReimer I think this is what you actually intended, otherwise I'm still getting settings files committed